### PR TITLE
prerequisite crawler

### DIFF
--- a/crawler/prerequisite.py
+++ b/crawler/prerequisite.py
@@ -1,0 +1,78 @@
+# -*- encoding: utf-8 -*-
+
+from collections import defaultdict
+
+import requests
+import lxml.html
+
+
+listing_url = (
+    'https://www.ccxp.nthu.edu.tw/ccxp/INQUIRE/JH/6/6.2/6.2.6/JH626001.php'
+)
+
+
+class Any(list):
+    def __repr__(self):
+        return 'Any({})'.format(super(Any, self).__repr__())
+
+
+class All(list):
+    def __repr__(self):
+        return 'All({})'.format(super(All, self).__repr__())
+
+
+class Not(tuple):
+    def __repr__(self):
+        return 'Not{}'.format(super(Not, self).__repr__())
+
+
+def extract_text(element):
+    return ''.join(element.xpath('.//text()')).strip()
+
+
+def extract_rows(element):
+    return [o.strip() for o in element.xpath('.//text()')]
+
+
+def get_document():
+    r = requests.get(listing_url)
+    r.encoding = 'cp950'
+    return lxml.html.fromstring(r.text)
+
+
+def iter_rows(document):
+    trs = document.xpath('//tr[@valign="top"]')
+    first = None
+
+    for tr in trs:
+        tds = tr.xpath('td')
+        if len(tds) == 5:
+            first, tds = tds[0], tds[1:]
+        else:
+            assert len(tds) == 4, len(tds)
+        course = extract_text(first)
+        requires = extract_rows(tds[0])
+        scAnye = extract_rows(tds[1])
+        note = extract_text(tds[2])
+        object_ = extract_text(tds[3]).replace('&nbsp', '')
+        assert len(requires) == len(scAnye), (course, requires, scAnye)
+        yield course, requires, scAnye, note, object_
+
+
+def get_prerequisites():
+    result = defaultdict(All)
+    for course, requires, scAnye, note, object_ in iter_rows(get_document()):
+        target = result[course, object_]
+        req_pairs = zip(requires, scAnye)
+        if not note:
+            target.extend(req_pairs)
+        elif note == u'任選一科':
+            target.append(Any(req_pairs))
+        elif note == u'修過「先修科目」者，不可修「欲修科目」':
+            target.extend(map(Not, req_pairs))
+    return result
+
+
+if __name__ == '__main__':
+    import pprint
+    pprint.pprint(get_prerequisites())

--- a/crawler/prerequisite.py
+++ b/crawler/prerequisite.py
@@ -70,6 +70,8 @@ def get_prerequisites():
             target.append(Any(req_pairs))
         elif note == u'修過「先修科目」者，不可修「欲修科目」':
             target.extend(map(Not, req_pairs))
+        else:
+            assert False, 'unexpected note %r' % note
     return result
 
 


### PR DESCRIPTION
``` python
crawler.prerequisite.get_prerequisites()
```

gives the following

``` python
{('中國思想史二', ''): All([('中國思想史一', '曾修')]),
 ('中國文學史二', ''): All([('中國文學史一', '曾修')]),
 ('中級日語一', '外語系'): All([Any([('日本語能力試驗N5級通過', '曾修'), ('初級日語二', '60 / C-'), ('日語一 (下)', '60 / C-')])]),
 ('中級日語二', '外語系'): All([Any([('日本語能力試驗N5級通過', '曾修'), ('日本交流協會三級測驗通過', '曾修'), ('中級日語一', '60 / C-'), ('日語二（上）', '60 / C-')])]),
 ('中級會計一', ''): All([('會計學二', '60 / C-')]),
 ('中級會計三', ''): All([('中級會計二', '60 / C-')]),
 ('中級會計二', ''): All([('中級會計一', '60 / C-')]),
 ('中級會計學一', ''): All([('會計學一', '60 / C-'), ('會計學二', '60 / C-')]),
 ('中級法語一', '外語系'): All([Any([('CEFR A1通過', '曾修'), ('初級法語二', '60 / C-'), ('法語一 (下)', '60 / C-')])]),
 ('中級法語二', '外語系'): All([Any([('CEFR A1通過', '曾修'), ('法國文化協會法語四級測驗通過', '曾修'), ('中級法語一', '60 / C-'), ('法語二（上）', '60 / C-')])]),
 ('中級英聽', '外語系'): All([('英語聽講二', '60 / C-')]),
 ('中級西班牙語一', '外語系'): All([Any([('CEFR A1通過', '曾修'), ('初級西班牙語二', '60 / C-')])]),
 ('中級西班牙語二', '外語系'): All([Any([('CEFR A1通過', '曾修'), ('中級西班牙語一', '60 / C-')])]),
 ('中醫與現代生活 一', ''): All([Not('中醫與現代生活', '曾修')]),
 ('中醫與現代生活二', ''): All([Not('進階中醫', '曾修'), Not('認識中醫', '曾修')]),
 ('人類學思潮', ''): All([('文化人類學導論', '60 / C-')]),
 ('人類學田野工作與實習', ''): All([('人類學方法論', '70 / B-')]),
 ('人類學研究方法', ''): All([('文化人類學導論', '60 / C-')]),
 ('代數二', ''): All([Any([('代數', '50 / D'), ('代數一', '50 / D')])]),
 ('作業研究一', '大學部'): All([Any([('工程數學一', '60 / C-'), ('線性代數一', '60 / C-'), ('線性代數', '60 / C-'), ('工程數學一：線性代數', '60 / C-')])]),
 ('作業研究二', '大學部'): All([Any([('工程統計一', '60 / C-'), ('機率論', '60 / C-')])]),
 ('個體經濟學一', ''): All([('經濟學原理一', '曾修')]),
 ('個體經濟學二', ''): All([('個體經濟學一', '曾修')]),
}
# truncated
# unicode strings translated
```
