### PR TITLE
except also OSError

### DIFF
--- a/crawler/decaptcha.py
+++ b/crawler/decaptcha.py
@@ -233,7 +233,7 @@ class AISEntrance(Entrance):
 # tesseract availability test
 try:
     versions = tesseract_versions()
-except subprocess.CalledProcessError:
+except (subprocess.CalledProcessError, OSError):
     raise ImportError('%r requires tesseract binary' % __name__)
 else:
     major, minor = map(int, versions.splitlines()[0].split()[-1].split(b'.'))


### PR DESCRIPTION
`subprocess.check_call` raises `OSError` if the binary does not exist
