### PR TITLE
crawler with SessionsFutures

### DIFF
--- a/crawler/course.py
+++ b/crawler/course.py
@@ -17,7 +17,7 @@ attachment_url = 'https://www.ccxp.nthu.edu.tw/ccxp/INQUIRE/JH/output/6_6.1_6.1.
 
 def xpath0(element, xpath):
     result = element.xpath(xpath)
-    assert len(result), result
+    assert len(result) == 1, result
     return result[0]
 
 

--- a/crawler/crawler.py
+++ b/crawler/crawler.py
@@ -96,7 +96,7 @@ def crawl_course(ACIXSTORE, auth_num, cou_codes):
             for cou_code in cou_codes
         ]
 
-    progress = progressbar.ProgressBar()
+    progress = progressbar.ProgressBar(maxval=len(cou_codes))
     for future, cou_code in progress(
         itertools.izip(curriculum_futures, cou_codes)
     ):
@@ -121,9 +121,9 @@ def crawl_course(ACIXSTORE, auth_num, cou_codes):
 
         progress = progressbar.ProgressBar(maxval=len(course_list))
         with transaction.atomic():
-            for future, course in progress(
-                course_futures, course_list)
-            ):
+            for future, course in progress(itertools.izip_longest(
+                course_futures, course_list
+            )):
                 response = future.result()
                 response.encoding = 'cp950'
                 save_syllabus(response.text, course)

--- a/crawler/crawler.py
+++ b/crawler/crawler.py
@@ -20,6 +20,8 @@ cond = 'a'
 T_YEAR = 104
 C_TERM = 10
 
+G_IMAP_SIZE = 4  # concurrent requests running the same time for grequests
+
 
 def dept_2_response(dept, ACIXSTORE, auth_num):
     return grequests.post(
@@ -94,7 +96,7 @@ def crawl_course(ACIXSTORE, auth_num, cou_codes):
     )
     progress = progressbar.ProgressBar(maxval=len(cou_codes))
     for response, cou_code in progress(
-        itertools.izip(grequests.imap(grs), cou_codes)
+        itertools.izip(grequests.imap(grs, size=G_IMAP_SIZE), cou_codes)
     ):
         response.encoding = 'cp950'
         handle_curriculum_html(response.text, cou_code)
@@ -116,7 +118,7 @@ def crawl_course(ACIXSTORE, auth_num, cou_codes):
     progress = progressbar.ProgressBar(maxval=len(course_list))
     with transaction.atomic():
         for response, course in progress(
-            itertools.izip(grequests.imap(grs), course_list)
+            itertools.izip(grequests.imap(grs, size=G_IMAP_SIZE), course_list)
         ):
             response.encoding = 'cp950'
             save_syllabus(response.text, course)
@@ -161,7 +163,7 @@ def crawl_dept(ACIXSTORE, auth_num, dept_codes):
 
     progress = progressbar.ProgressBar(maxval=len(dept_codes))
     with transaction.atomic():
-        for response in progress(grequests.imap(grs)):
+        for response in progress(grequests.imap(grs, size=G_IMAP_SIZE)):
             response.encoding = 'cp950'
             handle_dept_html(response.text)
 

--- a/crawler/crawler.py
+++ b/crawler/crawler.py
@@ -96,13 +96,14 @@ def crawl_course(ACIXSTORE, auth_num, cou_codes):
             for cou_code in cou_codes
         ]
 
-    progress = progressbar.ProgressBar(maxval=len(cou_codes))
-    for future, cou_code in progress(
-        itertools.izip(curriculum_futures, cou_codes)
-    ):
-        response = future.result()
-        response.encoding = 'cp950'
-        handle_curriculum_html(response.text, cou_code)
+        progress = progressbar.ProgressBar(maxval=len(cou_codes))
+        with transaction.atomic():
+            for future, cou_code in progress(
+                itertools.izip(curriculum_futures, cou_codes)
+            ):
+                response = future.result()
+                response.encoding = 'cp950'
+                handle_curriculum_html(response.text, cou_code)
 
     print 'Crawling syllabus...'
     course_list = list(Course.objects.all())

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ Whoosh==2.7.0
 git+https://github.com/henryyang42/django-haystack.git
 django-bootstrap-form==3.2
 lxml==3.4.4
-grequests
+requests-futures

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ Whoosh==2.7.0
 git+https://github.com/henryyang42/django-haystack.git
 django-bootstrap-form==3.2
 lxml==3.4.4
-threadpool
+grequests


### PR DESCRIPTION
### Notes
- use `FuturesSession`, new dependency: `request_futures`
- `threadpool` no longer required
- no (or less)`gg` in `crawl_dept`
- say goodbye to `OperationalError: FATAL: sorry, too many clients already`
- use `transaction.atomic()` to avoid constant committing
- current master's `collect_class_info` may run into race condition and cause `MultipleObjectsReturned`
- possibly faster than current master

local test with postgres

| branch (commit) | time |
| --- | --- |
| This PR (bcab019) | 290.139 |
| current dev (15eb066) | 342.852 |
| current master (0454849) | 352.280 |
### TODO
- error handling
- verify crawled data
