### PR TITLE
Fix for English name in syllabus.

### DIFF
--- a/crawler/course.py
+++ b/crawler/course.py
@@ -162,14 +162,23 @@ def course_from_syllabus(html):
     def xpath_int(xpath):
         return extract_int(xpath0(document, xpath))
 
+    def patch_teacher(text):
+        '''
+        Save only Chinese names for teachers.
+
+        See issue #86.
+        '''
+        return re.sub(r'\([^)]*\)', '', text)
+
     return {
         'no': xpath_text('/html/body/div/table[1]/tr[2]/td[2]'),
         'name_zh': xpath_text('/html/body/div/table[1]/tr[3]/td[2]'),
         'name_en': xpath_text('/html/body/div/table[1]/tr[4]/td[2]'),
         'credit': xpath_text('/html/body/div/table[1]/tr[2]/td[4]'),
-        'teacher': xpath_text('/html/body/div/table[1]/tr[5]/td[2]'),
+        'teacher': patch_teacher(xpath_text(
+            '/html/body/div/table[1]/tr[5]/td[2]', joiner=', ')),
         'time': xpath_text('/html/body/div/table[1]/tr[6]/td[2]'),
-        'room': xpath_text('/html/body/div/table[1]/tr[6]/td[4]', joiner=' '),
+        'room': xpath_text('/html/body/div/table[1]/tr[6]/td[4]', joiner=', '),
         'syllabus': extract_multirow_text(
             xpath0(document, '/html/body/div/table[4]/tr[2]/td')),
         'has_attachment': bool(

--- a/crawler/course.py
+++ b/crawler/course.py
@@ -128,7 +128,7 @@ def course_from_tr(main_tr):
             text = text.strip()
         part[key] = text
     prerequisite = extract_text(tds[10])
-    if prerequisite == u'擋修':
+    if prerequisite == u'擋修' or u'先修科目' in prerequisite:
         part['has_prerequisite'] = True
     else:
         assert not prerequisite, 'unknown prerequisite %r' % prerequisite

--- a/data_center/models.py
+++ b/data_center/models.py
@@ -18,7 +18,7 @@ class Course(models.Model):
     time = models.CharField(max_length=20, blank=True)
     time_token = models.CharField(max_length=20, blank=True)
     teacher = models.CharField(max_length=40, blank=True)  # Only save Chinese
-    room = models.CharField(max_length=20, blank=True)
+    room = models.CharField(max_length=80, blank=True)
     credit = models.IntegerField(default=0)
     limit = models.IntegerField(default=0)
     prerequisite = models.BooleanField(default=False, blank=True)


### PR DESCRIPTION
See #86.

Changes:
- Remove English names in syllabus' teacher name
- Course.room has max_length=80 instead of 20
- Expect variants of prerequisite strings.

Courses can be crawled without errors after this patch :D

```
100% |###############################################|
Crawling syllabus...
100% |###############################################|
Total course information: 2923
100% |###############################################|
Total department information: 221
Total 175.991 second used.
```
