### PR TITLE
Classroom missing in syllabus page

### DIFF
--- a/search/templates/syllabus.html
+++ b/search/templates/syllabus.html
@@ -38,6 +38,10 @@
           <td class="class3">{{ course.teacher }}</td>
         </tr>
         <tr>
+          <td class="class2">教室</td>
+          <td class="class3">{{ course.room }}</td>
+        </tr>
+        <tr>
           <td class="class2">人數限制</td>
           <td class="class3">{{ course.size_limit }}</td>
         </tr>


### PR DESCRIPTION
Before PR
![image](https://cloud.githubusercontent.com/assets/4318379/12048150/329b7406-af12-11e5-804c-405ffcf30dee.png)
After PR
![image](https://cloud.githubusercontent.com/assets/4318379/12048157/44453660-af12-11e5-8731-9c26ea475e3e.png)

Although this PR targets branch `dev`, please consider also merging it into master (& deploying), as I've received a few private complaints about it.

I'm also considering rewriting the syllabus page. `"class1"` `"class2"` doesn't make sense (edit: to me), and neither does looking like the official one.
