### PR TITLE
incrase decaptcha successful rate from around 32% to 80%

### DIFF
--- a/crawler/decaptcha.py
+++ b/crawler/decaptcha.py
@@ -23,8 +23,7 @@ from PIL import Image
 try:
     from utils.config import get_config_section
 except ImportError:
-    captcha_url_base = \
-    'https://www.ccxp.nthu.edu.tw/ccxp/INQUIRE/JH/mod/auth_img/auth_img.php'
+    captcha_url_base = 'https://www.ccxp.nthu.edu.tw/ccxp/INQUIRE/JH/mod/auth_img/auth_img.php'  # noqa
 else:
     decaptcha_config = get_config_section('decaptcha')
     captcha_url_base = decaptcha_config['captcha_url_base']

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ git+https://github.com/henryyang42/django-haystack.git
 django-bootstrap-form==3.2
 lxml==3.4.4
 requests-futures
+pillow


### PR DESCRIPTION
- make decaptcha.py runnable alone
- add decaptcha benchmark: `python decaptcha.py --benchmark COUNT`
- preprocess the captcha to black & white before tesseract-ing
- added dependency: pillow
